### PR TITLE
get_figure_handle() has been removed in Scilab 2023.1.0

### DIFF
--- a/scilab_kernel/_make_figures.sci
+++ b/scilab_kernel/_make_figures.sci
@@ -12,6 +12,6 @@ function _make_figures(plot_dir, plot_format)
       else
         xs2svg(id, outfile);
       end
-      close(get_figure_handle(id));
+      close(id);
     end
  endfunction

--- a/scilab_kernel/kernel.py
+++ b/scilab_kernel/kernel.py
@@ -9,7 +9,7 @@ import sys
 import tempfile
 from xml.dom import minidom
 
-from metakernel import MetaKernel, ProcessMetaKernel, REPLWrapper, pexpect
+from metakernel import MetaKernel, ProcessMetaKernel, REPLWrapper
 from metakernel.pexpect import which
 from IPython.display import Image, SVG
 
@@ -34,9 +34,9 @@ class ScilabKernel(ProcessMetaKernel):
     language_version = __version__,
     banner = "Scilab Kernel",
     language_info = {
-        'name': 'scilab',
+        'name': 'octave',
         'file_extension': '.sci',
-        "mimetype": "text/x-scilab",
+        "mimetype": "text/x-octave",
         "version": __version__,
         'help_links': MetaKernel.help_links,
     }
@@ -52,15 +52,13 @@ class ScilabKernel(ProcessMetaKernel):
     _banner = None
 
     _executable = None
-    _default_args = None
 
     @property
     def executable(self):
         if self._executable:
             return self._executable
         executable = os.environ.get('SCILAB_EXECUTABLE', None)
-        self.log.warning('SCILAB_EXECUTABLE env. variable: ' + executable)
-        if not which(executable):
+        if not executable or not which(executable):
             if os.name == 'nt':
                 executable = 'WScilex-cli'
             else:
@@ -70,19 +68,14 @@ class ScilabKernel(ProcessMetaKernel):
                        '"SCILAB_EXECUTABLE" environment variable')
                 raise OSError(msg)
         if 'cli' not in executable:
-            self._default_args = ['-nw']
-        else:
-            self._default_args = []
-        self.log.debug(' scilab_kernel._executable: ' + executable)
-        self.log.debug(' scilab_kernel._default_args: ' + ' '.join(self._default_args))
+            executable + ' -nw'
         self._executable = executable
         return executable
 
     @property
     def banner(self):
         if self._banner is None:
-            executable = self.executable
-            call = [executable] + self._default_args + ['-version']
+            call = '%s -version -nwni || true' % self.executable
             banner = subprocess.check_output(call, shell=True)
             self._banner = banner.decode('utf-8')
         return self._banner
@@ -101,14 +94,11 @@ class ScilabKernel(ProcessMetaKernel):
         else:
             echo = True
         executable = self.executable
-        child = pexpect.spawnu(executable, self._default_args,
-            echo=echo,
-            codec_errors="ignore",
-            encoding="utf-8")
-        wrapper = REPLWrapper(child, orig_prompt, change_prompt,
+        with open(os.path.expanduser('~/test.log'), 'w') as fid:
+            fid.write('executable: ' + executable)
+        wrapper = REPLWrapper(executable, orig_prompt, change_prompt,
             prompt_emit_cmd=prompt_cmd, echo=echo,
             continuation_prompt_regex=continuation_prompt)
-        
         wrapper.child.linesep = '\r\n' if os.name == 'nt' else '\n'
         return wrapper
 
@@ -123,7 +113,6 @@ class ScilabKernel(ProcessMetaKernel):
     def do_execute_direct(self, code, silent=False):
         if self._first:
             self._first = False
-            self.log.debug('execute first:' + code)
             self.handle_plot_settings()
             setup = self._setup.strip()
             self.do_execute_direct(setup, True)


### PR DESCRIPTION
`get_figure_handle()` is deprecated since 6.1.1 https://help.scilab.org/docs/6.1.1/en_US/get_figure_handle.html

Fixes #24 