### PR TITLE
detect macOS Scilab application bundle

### DIFF
--- a/scilab_kernel/kernel.py
+++ b/scilab_kernel/kernel.py
@@ -112,7 +112,18 @@ class ScilabKernel(ProcessMetaKernel):
                     yield executable
             except FileNotFoundError:
                 pass
-        
+
+        # detect macOS bundle
+        if platform.system() == 'Darwin':
+            process = subprocess.run(['mdfind', '-onlyin', '/Applications', 'kMDItemCFBundleIdentifier=org.scilab.modules.jvm.Scilab'], 
+                                 stdout=subprocess.PIPE, 
+                                 universal_newlines=True)
+            bundles = process.stdout
+            if len(bundles) > 0:
+                executable = bundles.split('\n', 1)[0] + "/Contents/bin/scilab-adv-cli"
+                self.log.warning('macOS Application binary: ' + executable)
+                yield executable
+
         # detect on the path
         if os.name == 'nt':
             executable = 'WScilex-cli'


### PR DESCRIPTION
The detection is made by using the mdfind command, as the Scilab bundle id is well defined:
```
mdfind -onlyin /Applications kMDItemCFBundleIdentifier=org.scilab.modules.jvm.Scilab
```
When different versions are present in /Applications/ the more recent one is on the first line, e.g.
```
/Applications/scilab-2024.1.0.app
/Applications/scilab-2024.0.0.app
```
Proposed implementation always take the more recent version.